### PR TITLE
[Feat]  user·map API React Query 훅 및 캐시 키 정리

### DIFF
--- a/frontend/src/queries/api/map/index.ts
+++ b/frontend/src/queries/api/map/index.ts
@@ -1,0 +1,17 @@
+import { locationMapKey } from "@/queries/api/map/location/type"
+import { categoryMapKey } from "@/queries/api/map/category/type"
+import { businessMapKey } from "@/queries/api/map/business/type"
+import { analysisMapKey } from "@/queries/api/map/analysis/type"
+
+export type { TypeLocationListAllId, TypeLocationListAllFilter } from "@/queries/api/map/location/type"
+export type { TypeCategoryListAllId, TypeCategoryListAllFilter } from "@/queries/api/map/category/type"
+export { TypeCategoryCode } from "@/components/form/SearchCategory/type"
+export type { TypeBusinessListAllId } from "@/queries/api/map/business/type"
+export type { TypeAnalysisListAllFilter, TypeAnalysisListAllId } from "@/queries/api/map/analysis/type"
+
+export const mapKey = {
+  location: locationMapKey,
+  category: categoryMapKey,
+  business: businessMapKey,
+  analysis: analysisMapKey,
+}

--- a/frontend/src/queries/api/map/useSearchAnalysisList.ts
+++ b/frontend/src/queries/api/map/useSearchAnalysisList.ts
@@ -1,0 +1,71 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { isEquals } from "@/libs/utils"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { TypeAnalysisListAllId, TypeAnalysisListAllFilter, mapKey } from "@/queries/api/map"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchAnalysisResult = {
+  count: number
+  includesUnserviceableAreas: boolean
+  labels: [string, string, string, string, string, string]
+  businessAttractions: {
+    legalDistrictCode: string
+    administrativeDistrictName: string
+    businessAttractionScores: [number, number, number, number, number, number]
+    totalScore: number
+    coordinates: { latitude: number; longitude: number }
+  }[]
+}
+
+export const fetchSearchAnalysisList: TypeFetchList<
+  TypeSearchAnalysisResult,
+  TypeAnalysisListAllId,
+  TypeAnalysisListAllFilter
+> = async (page, { level, searchBounds, businessCode }) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get( `${process.env.NEXT_PUBLIC_API_URL}/api/map/business-attraction`, {
+  //   params: {
+  //     page,
+  //     rect: searchBounds.join(","),
+  //     serviceIndustryCode: businessCode,
+  //   },
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/map/business-attraction`, {
+    params: {
+      page,
+      rect: searchBounds.join(","),
+      serviceIndustryCode: businessCode,
+    },
+    headers: {
+      //
+    },
+  })
+  return data
+}
+
+const useSearchAnalysisList = (
+  page: TypeAnalysisListAllId,
+  { level, searchBounds, businessCode }: TypeAnalysisListAllFilter,
+) => {
+  const context = useQuery({
+    queryKey: getCacheKey(mapKey).analysis.list.all.toKeyWithArgs(page, { level, searchBounds, businessCode }),
+    queryFn: async () => {
+      const data = await fetchSearchAnalysisList(page, { level, searchBounds, businessCode })
+      return data
+    },
+    enabled: !!page && !!businessCode && !isEquals([0, 0, 0, 0], searchBounds) && [1, 2, 3].includes(level),
+    staleTime: 1000 * 60 * 60 * 23,
+    gcTime: 1000 * 60 * 60 * 24,
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchAnalysisList

--- a/frontend/src/queries/api/map/useSearchBusinessList.ts
+++ b/frontend/src/queries/api/map/useSearchBusinessList.ts
@@ -1,0 +1,33 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { getCacheKey } from "@/libs/cache"
+import { TypeBusinessListAllId, mapKey } from "@/queries/api/map"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchBusinessResult = {
+  [key in string]: string
+}
+
+export const fetchSearchBusinessList: TypeFetchList<TypeSearchBusinessResult, TypeBusinessListAllId> = async (page) => {
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/map/serviceIndustryData`)
+  return data
+}
+
+const useSearchBusinessListList = (page: TypeBusinessListAllId) => {
+  const context = useQuery({
+    queryKey: getCacheKey(mapKey).business.list.all.toKeyWithArgs(page),
+    queryFn: async () => {
+      const data = await fetchSearchBusinessList(page, {})
+      return data
+    },
+    enabled: !!page,
+    staleTime: 1000 * 60 * 60 * 23,
+    gcTime: 1000 * 60 * 60 * 24,
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchBusinessListList

--- a/frontend/src/queries/api/map/useSearchCategoryList.ts
+++ b/frontend/src/queries/api/map/useSearchCategoryList.ts
@@ -1,0 +1,74 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { isEquals } from "@/libs/utils"
+import { getCacheKey } from "@/libs/cache"
+import { TypeCategoryListAllId, TypeCategoryListAllFilter, mapKey } from "@/queries/api/map"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchCategoryResult = {
+  meta: {
+    total_count: number
+    pageable_count: number
+    is_end: boolean
+    same_name: {
+      region: string[]
+      keyword: string
+      selected_region: string
+    } | null
+  }
+  documents: {
+    id: string
+    place_name: string
+    category_name: string
+    category_group_code: string
+    category_group_name: string
+    phone: string
+    address_name: string
+    road_address_name: string
+    x: string
+    y: string
+    place_url: string
+    distance: string
+  }[]
+}
+
+export const fetchSearchCategoryList: TypeFetchList<
+  TypeSearchCategoryResult,
+  TypeCategoryListAllId,
+  TypeCategoryListAllFilter
+> = async (page, { level, categoryCode, searchBounds, size }) => {
+  const { data } = await axios.get(`/map/search-category`, {
+    params: {
+      page,
+      size,
+      category_group_code: categoryCode,
+      rect: `${searchBounds[1]},${searchBounds[0]},${searchBounds[3]},${searchBounds[2]}`,
+    },
+    headers: {
+      Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_API_KAKAO_REST_KEY}`,
+    },
+  })
+  return data
+}
+
+const useSearchCategoryList = (
+  page: TypeCategoryListAllId,
+  { level, categoryCode, searchBounds, size }: TypeCategoryListAllFilter,
+) => {
+  const context = useQuery({
+    queryKey: getCacheKey(mapKey).category.list.all.toKeyWithArgs(page, { level, categoryCode, searchBounds, size }),
+    queryFn: async () => {
+      const data = await fetchSearchCategoryList(page, { level, categoryCode, searchBounds, size })
+      return data
+    },
+    enabled: !!page && !!categoryCode && !isEquals([0, 0, 0, 0], searchBounds) && [1, 2, 3].includes(level),
+    staleTime: 1000 * 60 * 60 * 23,
+    gcTime: 1000 * 60 * 60 * 24,
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchCategoryList

--- a/frontend/src/queries/api/map/useSearchLocationList.ts
+++ b/frontend/src/queries/api/map/useSearchLocationList.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react"
+import axios from "axios"
+import { useInfiniteQuery } from "@tanstack/react-query"
+import { getCacheKey } from "@/libs/cache"
+import { mapKey, TypeLocationListAllId, TypeLocationListAllFilter } from "@/queries/api/map"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchLocationResult = {
+  meta: {
+    is_end: boolean
+    pageable_count: number
+    total_count: number
+  }
+  documents: {
+    address_name: string
+    y: string
+    x: string
+    address_type: string
+    address: {
+      address_name: string
+      region_1depth_name: string
+      region_2depth_name: string
+      region_3depth_name: string
+      region_3depth_h_name: string
+      h_code: string
+      b_code: string
+      mountain_yn: string
+      main_address_no: string
+      sub_address_no: string
+      x: string
+      y: string
+    }
+    road_address: {
+      address_name: string
+      region_1depth_name: string
+      region_2depth_name: string
+      region_3depth_name: string
+      road_name: string
+      underground_yn: string
+      main_building_no: string
+      sub_building_no: string
+      building_name: string
+      zone_no: string
+      y: string
+      x: string
+    } | null
+  }[]
+}
+
+export const fetchSearchLocationList: TypeFetchList<
+  TypeSearchLocationResult,
+  TypeLocationListAllId,
+  TypeLocationListAllFilter
+> = async (page, { searchKeyword }) => {
+  const { data } = await axios.get(`/map/search-location`, {
+    params: {
+      page: page,
+      query: encodeURIComponent(searchKeyword),
+    },
+    headers: {
+      Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_API_KAKAO_REST_KEY}`,
+    },
+  })
+  return data
+}
+
+const useSearchLocationList = ({ searchKeyword }: TypeLocationListAllFilter) => {
+  const context = useInfiniteQuery({
+    queryKey: getCacheKey(mapKey).location.list.all.toKeyWithArgs(Infinity, { searchKeyword }),
+    queryFn: async ({ pageParam = 1 }: { pageParam: TypeLocationListAllId }) => {
+      const data = await fetchSearchLocationList(pageParam, { searchKeyword })
+      return data
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      return !lastPage.meta.is_end ? allPages.length + 1 : undefined
+    },
+    initialPageParam: 1,
+    enabled: !!searchKeyword,
+    staleTime: 1000 * 60 * 60 * 23,
+    gcTime: 1000 * 60 * 60 * 24,
+  })
+
+  const flatData = useMemo(() => {
+    if (!context.data || !context.data.pages) return []
+    return context.data.pages.flatMap((page) => page.documents)
+  }, [context.data])
+
+  return {
+    ...context,
+    flatData,
+    isSelected: flatData.length === 1 && searchKeyword === flatData[0].address_name,
+  }
+}
+
+export default useSearchLocationList

--- a/frontend/src/queries/api/user/index.ts
+++ b/frontend/src/queries/api/user/index.ts
@@ -1,0 +1,19 @@
+import { profileKey } from "@/queries/api/user/profile/type"
+import { myplaceKey } from "@/queries/api/user/myplace/type"
+import { membershipKey } from "@/queries/api/user/membership/type"
+import { paymentKey } from "@/queries/api/user/payment/type"
+
+export type { TypeMyplaceListAllId, TypeMyplaceListAllFilter } from "@/queries/api/user/myplace/type"
+export type { TypeMyplaceDetailDefaultId } from "@/queries/api/user/myplace/type"
+export type {
+  TypePaymentListAllId,
+  TypePaymentListAllFilter,
+  TypePaymentDetailId,
+} from "@/queries/api/user/payment/type"
+
+export const userKey = {
+  profile: profileKey,
+  myplace: myplaceKey,
+  membership: membershipKey,
+  payment: paymentKey,
+}

--- a/frontend/src/queries/api/user/uesMutationMembership.ts
+++ b/frontend/src/queries/api/user/uesMutationMembership.ts
@@ -1,0 +1,77 @@
+import axios, { AxiosError } from "axios"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypePostMembershipParams = {
+  subscriptionCode: string
+}
+
+export type TypePostMembershipResult = null
+
+export const postMembership: TypeFetchList<TypePostMembershipResult, null, TypePostMembershipParams> = async (
+  key,
+  { subscriptionCode },
+) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.post(
+  //   `${process.env.NEXT_PUBLIC_API_URL}/api/membership`,
+  //   {
+  //     subscriptionCode
+  //   },
+  //   {
+  //     headers: {
+  //       "Content-Type": "application/json",
+  //     },
+  //   },
+  // )
+  const { data } = await axios.post(
+    `${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/membership`,
+    {
+      subscriptionCode,
+    },
+    {
+      headers: {
+        //
+      },
+    },
+  )
+  return data
+}
+
+const useMutationMembership = () => {
+  const queryClient = useQueryClient()
+
+  const handleOnSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: getCacheKey(userKey).profile.default.toKey() })
+    queryClient.invalidateQueries({ queryKey: getCacheKey(userKey).membership.default.toKey() })
+  }
+
+  const { mutateAsync: postMembershipAsync, status: postMembershipStatus } = useMutation<
+    TypePostMembershipResult,
+    AxiosError,
+    TypePostMembershipParams
+  >({
+    mutationFn: async ({ subscriptionCode }) => {
+      const data = await postMembership(null, { subscriptionCode })
+      return data
+    },
+    onSuccess: () => {
+      handleOnSuccess()
+    },
+    onError: (error) => {
+      // TODO
+      alert("저장 실패!")
+      console.error(error)
+    },
+  })
+
+  return {
+    postMembershipAsync,
+    postMembershipStatus,
+  }
+}
+
+export default useMutationMembership

--- a/frontend/src/queries/api/user/uesMutationProfile.ts
+++ b/frontend/src/queries/api/user/uesMutationProfile.ts
@@ -1,0 +1,79 @@
+import axios, { AxiosError } from "axios"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypePostProfileParams = {
+  name: string
+  email: string
+}
+
+export type TypePostProfileResult = null
+
+export const postProfile: TypeFetchList<TypePostProfileResult, null, TypePostProfileParams> = async (
+  key,
+  { name, email },
+) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.post(
+  //   `${process.env.NEXT_PUBLIC_API_URL}/api/profile`,
+  //   {
+  //     name,
+  //     email,
+  //   },
+  //   {
+  //     headers: {
+  //       "Content-Type": "application/json",
+  //     },
+  //   },
+  // )
+  const { data } = await axios.post(
+    `${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/profile`,
+    {
+      name,
+      email,
+    },
+    {
+      headers: {
+        //
+      },
+    },
+  )
+  return data
+}
+
+const useMutationProfile = () => {
+  const queryClient = useQueryClient()
+
+  const handleOnSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: getCacheKey(userKey).profile.default.toKey() })
+  }
+
+  const { mutateAsync: postProfileAsync, status: postProfileStatus } = useMutation<
+    TypePostProfileResult,
+    AxiosError,
+    TypePostProfileParams
+  >({
+    mutationFn: async ({ name, email }) => {
+      const data = await postProfile(null, { name, email })
+      return data
+    },
+    onSuccess: () => {
+      handleOnSuccess()
+    },
+    onError: (error) => {
+      // TODO
+      alert("저장 실패!")
+      console.error(error)
+    },
+  })
+
+  return {
+    postProfileAsync,
+    postProfileStatus,
+  }
+}
+
+export default useMutationProfile

--- a/frontend/src/queries/api/user/useMutationMyplaceDetail.ts
+++ b/frontend/src/queries/api/user/useMutationMyplaceDetail.ts
@@ -1,0 +1,127 @@
+import axios, { AxiosError } from "axios"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { TypeMyplaceDetailDefaultId, userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypePostMyplaceDetailParams = {
+  id: string
+  addressName: string
+  coordinates: {
+    latitude: number
+    longitude: number
+  }
+}
+
+export type TypePostMyplaceDetailResult = null
+
+export type TypeDeleteMyplaceDetailResult = null
+
+export const postMyplaceDetail: TypeFetchList<TypePostMyplaceDetailResult, null, TypePostMyplaceDetailParams> = async (
+  key,
+  { id, addressName, coordinates },
+) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.post(
+  //   `${process.env.NEXT_PUBLIC_API_URL}/api/myplace`,
+  //   {
+  //     id,
+  //     addressName,
+  //     coordinates,
+  //   },
+  //   {
+  //     headers: {
+  //       "Content-Type": "application/json",
+  //     },
+  //   },
+  // )
+  const { data } = await axios.post(
+    `${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/myplace`,
+    {
+      id,
+      addressName,
+      coordinates,
+    },
+    {
+      headers: {
+        //
+      },
+    },
+  )
+  return data
+}
+
+export const deleteMyplaceDetail: TypeFetchList<TypeDeleteMyplaceDetailResult, TypeMyplaceDetailDefaultId> = async (
+  id,
+) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/api/myplace/${id}`,{
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.delete(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/myplace/${id}`, {
+    headers: {
+      //
+    },
+  })
+  return data
+}
+
+const useMutationMyplaceDetail = () => {
+  const queryClient = useQueryClient()
+
+  const handleOnSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: getCacheKey(userKey).myplace.list.toKey() })
+  }
+
+  const { mutateAsync: postMyplaceDetailAsync, status: postMyplaceDetailStatus } = useMutation<
+    TypePostMyplaceDetailResult,
+    AxiosError,
+    TypePostMyplaceDetailParams
+  >({
+    mutationFn: async ({ id, addressName, coordinates }) => {
+      const data = await postMyplaceDetail(null, { id, addressName, coordinates })
+      return data
+    },
+    onSuccess: () => {
+      handleOnSuccess()
+    },
+    onError: (error) => {
+      // TODO
+      alert("등록 실패!")
+      console.error(error)
+    },
+  })
+
+  // delete
+  const { mutateAsync: deleteMyplaceDetailAsync, status: deleteMyplaceDetailStatus } = useMutation<
+    TypeDeleteMyplaceDetailResult,
+    AxiosError,
+    { id: TypeMyplaceDetailDefaultId }
+  >({
+    mutationFn: async ({ id }) => {
+      const data = await deleteMyplaceDetail(id, {})
+      return data
+    },
+    onSuccess: () => {
+      handleOnSuccess()
+    },
+    onError: (error) => {
+      // TODO
+      alert("삭제 실패!")
+      console.error(error)
+    },
+  })
+
+  return {
+    postMyplaceDetailAsync,
+    postMyplaceDetailStatus,
+    deleteMyplaceDetailAsync,
+    deleteMyplaceDetailStatus,
+  }
+}
+
+export default useMutationMyplaceDetail

--- a/frontend/src/queries/api/user/useSearchMembership.ts
+++ b/frontend/src/queries/api/user/useSearchMembership.ts
@@ -1,0 +1,46 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchMembershipResult = {
+  isSubscribed: boolean
+  subscriptionCode: string
+  effectiveDate?: Date
+  expirationDate?: Date
+  paymentMethod?: string
+  paymentInfo?: string
+  paymentAmount?: number
+  refundAmount?: number
+}
+
+export const fetchSearchMembership: TypeFetchList<TypeSearchMembershipResult, null> = async (key) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/membership`, {
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/membership`, {
+    //
+  })
+  return data
+}
+
+const useSearchMembership = () => {
+  const context = useQuery({
+    queryKey: getCacheKey(userKey).membership.default.toKey(),
+    queryFn: async () => {
+      const data = await fetchSearchMembership(null, {})
+      return data
+    },
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchMembership

--- a/frontend/src/queries/api/user/useSearchMyplaceList.ts
+++ b/frontend/src/queries/api/user/useSearchMyplaceList.ts
@@ -1,0 +1,61 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { TypeMyplaceListAllId, TypeMyplaceListAllFilter, userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchMyplaceResult = {
+  count: number
+  totalCount: number
+  items: {
+    id: number
+    addressName: string
+    totalScore: number
+    coordinates: {
+      latitude: number
+      longitude: number
+    }
+  }[]
+}
+
+export const fetchSearchMyplaceList: TypeFetchList<
+  TypeSearchMyplaceResult,
+  TypeMyplaceListAllId,
+  TypeMyplaceListAllFilter
+> = async (page, { size }) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/myplace`, {
+  //   params: {
+  //     page,
+  //     size,
+  //   },
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/myplace`, {
+    params: {
+      page,
+      size,
+    },
+  })
+  return data
+}
+
+const useSearchMyplaceList = (page: TypeMyplaceListAllId, { size }: TypeMyplaceListAllFilter) => {
+  const context = useQuery({
+    queryKey: getCacheKey(userKey).myplace.list.all.toKeyWithArgs(page, { size }),
+    queryFn: async () => {
+      const data = await fetchSearchMyplaceList(page, { size })
+      return data
+    },
+    enabled: !!page && !!size,
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchMyplaceList

--- a/frontend/src/queries/api/user/useSearchPaymentDetail.ts
+++ b/frontend/src/queries/api/user/useSearchPaymentDetail.ts
@@ -1,0 +1,59 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { TypePaymentDetailId, userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+import { TypeSubscriptionCode } from "@/components/form/ChangeMembership/type"
+import { TypePaymentStateCode } from "@/components/form/SearchPayment/type"
+
+export type TypeSearchPaymentDetailResult = {
+  id: number
+  subscriptionCode: TypeSubscriptionCode
+  effectiveDate: Date
+  expirationDate: Date
+  paymentMethod: string
+  paymentInfo: string
+  paymentState: TypePaymentStateCode
+  paymentAmount: number
+  paymentDate: Date
+  billingDate: Date
+  errorCode?: string
+  errorMessage?: string
+}
+
+export const fetchSearchPaymentDetail: TypeFetchList<TypeSearchPaymentDetailResult, TypePaymentDetailId> = async (
+  id,
+) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/payment/${id}`, {
+  //   params: {
+  //
+  //   },
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/payment/${id}`, {
+    params: {
+      //
+    },
+  })
+  return data
+}
+
+const useSearchPaymentDetail = (id: TypePaymentDetailId) => {
+  const context = useQuery({
+    queryKey: getCacheKey(userKey).payment.detail.toKeyWithArgs(id),
+    queryFn: async () => {
+      const data = await fetchSearchPaymentDetail(id, {})
+      return data
+    },
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchPaymentDetail

--- a/frontend/src/queries/api/user/useSearchPaymentList.ts
+++ b/frontend/src/queries/api/user/useSearchPaymentList.ts
@@ -1,0 +1,84 @@
+import axios from "axios"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { TypePaymentListAllId, TypePaymentListAllFilter, userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+import { TypeSubscriptionCode } from "@/components/form/ChangeMembership/type"
+import { TypePaymentStateCode } from "@/components/form/SearchPayment/type"
+
+export type TypeSearchPaymentListResult = {
+  count: number
+  totalCount: number
+  items: {
+    id: number
+    subscriptionCode: TypeSubscriptionCode
+    effectiveDate: Date
+    expirationDate: Date
+    paymentMethod: string
+    paymentInfo: string
+    paymentState: TypePaymentStateCode
+    paymentAmount: number
+    paymentDate: Date
+    billingDate: Date
+    errorCode?: string
+    errorMessage?: string
+  }[]
+}
+
+export const fetchSearchPaymentList: TypeFetchList<
+  TypeSearchPaymentListResult,
+  TypePaymentListAllId,
+  TypePaymentListAllFilter
+> = async (page, { size, paymentPeriodCode, paymentStateCode, startDate, endDate }) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/payment`, {
+  //   params: {
+  //     size,
+  //     paymentPeriodCode,
+  //     paymentStateCode,
+  //     startDate,
+  //     endDate,
+  //   },
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/payment`, {
+    params: {
+      size,
+      paymentPeriodCode,
+      paymentStateCode,
+      startDate,
+      endDate,
+    },
+  })
+  return data
+}
+
+const useSearchPaymentList = (
+  page: TypePaymentListAllId,
+  { size, paymentPeriodCode, paymentStateCode, startDate, endDate }: TypePaymentListAllFilter,
+) => {
+  const context = useQuery({
+    queryKey: getCacheKey(userKey).payment.list.all.toKeyWithArgs(page, {
+      size,
+      paymentPeriodCode,
+      paymentStateCode,
+      startDate,
+      endDate,
+    }),
+    queryFn: async () => {
+      const data = await fetchSearchPaymentList(page, { size, paymentPeriodCode, paymentStateCode, startDate, endDate })
+      return data
+    },
+    enabled: !!page && !!size,
+    placeholderData: keepPreviousData,
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchPaymentList

--- a/frontend/src/queries/api/user/useSearchProfile.ts
+++ b/frontend/src/queries/api/user/useSearchProfile.ts
@@ -1,0 +1,41 @@
+import axios from "axios"
+import { useQuery } from "@tanstack/react-query"
+import { getCacheKey, getToken } from "@/libs/cache"
+import { userKey } from "@/queries/api/user"
+import { TypeFetchList } from "@/types/cache"
+
+export type TypeSearchProfileResult = {
+  isSubscribed: boolean
+  name: string
+  email: string
+}
+
+export const fetchSearchProfile: TypeFetchList<TypeSearchProfileResult, null> = async (key) => {
+  // TODO
+  // const token = await getToken()
+  // const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/profile`, {
+  //   headers: {
+  //     Authorization: `Bearer ${token}`,
+  //   },
+  // })
+  const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_MOCKING_URL}/mocks/user/profile`, {
+    //
+  })
+  return data
+}
+
+const useSearchProfile = () => {
+  const context = useQuery({
+    queryKey: getCacheKey(userKey).profile.default.toKey(),
+    queryFn: async () => {
+      const data = await fetchSearchProfile(null, {})
+      return data
+    },
+  })
+
+  return {
+    ...context,
+  }
+}
+
+export default useSearchProfile


### PR DESCRIPTION
## 📑 작업 내용
`frontend/src/queries`에 사용자(user)·지도(map) API용 fetch 함수, useQuery / useInfiniteQuery / useMutation 훅, 도메인별 React Query 캐시 키(`userKey`, `mapKey`)를 추가하고 진입점에서 타입·키를 모았습니다.

## 🛠️ 작업 사항
- [x] `queries/api/user/index.ts` — `userKey`(profile·myplace·membership·payment) 집계 및 결제·내장소 관련 타입 re-export
- [x] User 조회: 프로필·멤버십·내 장소 목록·결제 목록·결제 상세 (`useSearch*`)
- [x] User 변경: 프로필 수정·멤버십 변경·내 장소 등록/삭제 (`uesMutation*` / `useMutation*`)
- [x] `queries/api/map/index.ts` — `mapKey`(location·category·business·analysis) 및 관련 타입 export
- [x] Map 조회: 주소 무한 스크롤·카테고리 POI·업종 데이터·상권 분석 목록 (`useSearch*`)
- [x] Map 도메인별 캐시 키·필터 타입 (`map/*/type.ts`)

## 🔗 관련 이슈
Resolves : #21 